### PR TITLE
Copy the dlls to a subdirectory of the output directory

### DIFF
--- a/nugetpackage/assets/lib/build/Icu4c.Win.Fw.Lib.props
+++ b/nugetpackage/assets/lib/build/Icu4c.Win.Fw.Lib.props
@@ -1,0 +1,12 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<PropertyGroup>
+		<CopyIcuLibrariesToOutput Condition="'$(CopyIcuLibrariesToOutput)' == ''">true</CopyIcuLibrariesToOutput>
+
+		<IcuFwRuntimesDirectory>$(MSBuildThisFileDirectory)..\runtimes\</IcuFwRuntimesDirectory>
+		<IcuFwRuntimeWinX86>$(IcuFwRuntimesDirectory)win7-x86\native\</IcuFwRuntimeWinX86>
+		<IcuFwRuntimeWinX64>$(IcuFwRuntimesDirectory)win7-x64\native\</IcuFwRuntimeWinX64>
+		<IcuFwIncludeDirectory>$(MSBuildThisFileDirectory)native\include\</IcuFwIncludeDirectory>
+		<IcuFwLibDirectoryX86>$(MSBuildThisFileDirectory)native\lib\win7-x86\</IcuFwLibDirectoryX86>
+		<IcuFwLibDirectoryX64>$(MSBuildThisFileDirectory)native\lib\win7-x64\</IcuFwLibDirectoryX64>
+	</PropertyGroup>
+</Project>

--- a/nugetpackage/assets/lib/build/Icu4c.Win.Fw.Lib.targets
+++ b/nugetpackage/assets/lib/build/Icu4c.Win.Fw.Lib.targets
@@ -1,11 +1,17 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<PropertyGroup>
-		<IcuFwRuntimesDirectory>$(MSBuildThisFileDirectory)..\runtimes\</IcuFwRuntimesDirectory>
-		<IcuFwRuntimeWinX86>$(IcuFwRuntimesDirectory)win7-x86\native\</IcuFwRuntimeWinX86>
-		<IcuFwRuntimeWinX64>$(IcuFwRuntimesDirectory)win7-x64\native\</IcuFwRuntimeWinX64>
-		<IcuFwIncludeDirectory>$(MSBuildThisFileDirectory)native\include\</IcuFwIncludeDirectory>
-		<IcuFwLibDirectoryX86>$(MSBuildThisFileDirectory)native\lib\win7-x86\</IcuFwLibDirectoryX86>
-		<IcuFwLibDirectoryX64>$(MSBuildThisFileDirectory)native\lib\win7-x64\</IcuFwLibDirectoryX64>
-	</PropertyGroup>
-	<!-- We now leave it up to the client to use these properties to put the files where they are needed. -->
+	<Target Name="CopyIcuLibrariesToOutput" Condition="$(CopyIcuLibrariesToOutput) == 'true' And '$(OS)'=='Windows_NT'" AfterTargets="CoreCompile">
+		<ItemGroup>
+			<IcuLibsX86 Include="$(IcuFwRuntimeWinX86)icu*.dll" />
+			<IcuLibsX64 Include="$(IcuFwRuntimeWinX64)icu*.dll" />
+		</ItemGroup>
+
+		<Copy
+			SourceFiles="@(IcuLibsX86)"
+			DestinationFiles="@(LibraryFiles->'$(OutputPath)/lib/win7-x86/%(Filename)%(Extension)')"
+			SkipUnchangedFiles="True" />
+		<Copy
+			SourceFiles="@(IcuLibsX64)"
+			DestinationFiles="@(LibraryFiles->'$(OutputPath)/lib/win7-x64/%(Filename)%(Extension)')"
+			SkipUnchangedFiles="True" />
+	</Target>
 </Project>


### PR DESCRIPTION
This change will cause the ICU dlls to be copied to the `lib/win7-*`
directory in the output directory in the project that references
the Icu4c.Win.FW.Lib nuget package. This can be disabled by setting
`CopyIcuLibrariesToOutput` to `false`.