### PR TITLE
chore: remove group password

### DIFF
--- a/.github/workflows/fw_icu4c_ci.yml
+++ b/.github/workflows/fw_icu4c_ci.yml
@@ -170,6 +170,7 @@ jobs:
             --build-in-place
           mv --verbose ../icu-fw* .
           sudo sbuild-adduser runner
+          sudo gpasswd --remove-password sbuild
           sg sbuild '${CI_SCRIPT_DIR}/bash/build-package \
             --dists "noble jammy" \
             --arches "amd64" \


### PR DESCRIPTION
It seems that with Ubuntu 24.04 the sbuild group has a password set.
This change removes the password so that we can use the `sg sbuild`
command without providing a password.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/icu/25)
<!-- Reviewable:end -->
